### PR TITLE
resolving #73 - Update ibm_db_adapter.rb

### DIFF
--- a/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
+++ b/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
@@ -648,6 +648,8 @@ module ActiveRecord
                 end
               when /DB2/i               # DB2 for zOS
                 case server_info.DBMS_VER
+		  when /11/ 		# DB2 for zOS version 11
+		    @servertype = IBM_DB2_ZOS.new(self, @isAr3)
                   when /09/             # DB2 for zOS version 9 and version 10
                     @servertype = IBM_DB2_ZOS.new(self, @isAr3)
                   when /10/


### PR DESCRIPTION
resolving #73 to support DB2 version 11.