### PR TITLE
fix segfaults #11

### DIFF
--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -10251,15 +10251,8 @@ VALUE ibm_db_fetch_assoc(int argc, VALUE *argv, VALUE self) {
   helper_args->error      =  &error;
   helper_args->funcType   =  FETCH_ASSOC;
 
-  #ifdef UNICODE_SUPPORT_VERSION    
-	ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-                        (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-	ret_val = helper_args->return_value;
-						
-  #else
-    ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  #endif
-   
+  ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
+
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {
     ruby_xfree( helper_args );
@@ -10340,13 +10333,7 @@ VALUE ibm_db_fetch_object(int argc, VALUE *argv, VALUE self)
   helper_args->error      =  &error;
   helper_args->funcType   =  FETCH_ASSOC;
 
-  #ifdef UNICODE_SUPPORT_VERSION    
-	ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-                              (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-	row_res->hash = helper_args->return_value;
-  #else
-    row_res->hash = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  #endif
+  row_res->hash = _ruby_ibm_db_bind_fetch_helper( helper_args );
 
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {
@@ -10423,17 +10410,7 @@ VALUE ibm_db_fetch_array(int argc, VALUE *argv, VALUE self)
   helper_args->error       =  &error;
   helper_args->funcType    =  FETCH_INDEX;
 
-  //Call without thread API to avoid the Thread lock.
   ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  
-  //#ifdef UNICODE_SUPPORT_VERSION    
-  //ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-  //                      (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-  //  ret_val = helper_args->return_value;
-  //					
-  //#else
-  //  ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  //#endif
 
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {
@@ -10504,13 +10481,7 @@ VALUE ibm_db_fetch_both(int argc, VALUE *argv, VALUE self)
   helper_args->error       =  &error;
   helper_args->funcType    =  FETCH_BOTH;
 
-  #ifdef UNICODE_SUPPORT_VERSION    
-	 ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-                        (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-	ret_val = helper_args->return_value;
-  #else
-    ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  #endif
+  ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
 
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {

--- a/IBM_DB_Driver/ibm_db.c
+++ b/IBM_DB_Driver/ibm_db.c
@@ -10251,15 +10251,8 @@ VALUE ibm_db_fetch_assoc(int argc, VALUE *argv, VALUE self) {
   helper_args->error      =  &error;
   helper_args->funcType   =  FETCH_ASSOC;
 
-  #ifdef UNICODE_SUPPORT_VERSION    
-	ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-                        (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-	ret_val = helper_args->return_value;
-						
-  #else
     ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  #endif
-   
+
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {
     ruby_xfree( helper_args );
@@ -10340,13 +10333,7 @@ VALUE ibm_db_fetch_object(int argc, VALUE *argv, VALUE self)
   helper_args->error      =  &error;
   helper_args->funcType   =  FETCH_ASSOC;
 
-  #ifdef UNICODE_SUPPORT_VERSION    
-	ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-                              (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-	row_res->hash = helper_args->return_value;
-  #else
-    row_res->hash = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  #endif
+  row_res->hash = _ruby_ibm_db_bind_fetch_helper( helper_args );
 
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {
@@ -10423,17 +10410,7 @@ VALUE ibm_db_fetch_array(int argc, VALUE *argv, VALUE self)
   helper_args->error       =  &error;
   helper_args->funcType    =  FETCH_INDEX;
 
-  //Call without thread API to avoid the Thread lock.
   ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  
-  //#ifdef UNICODE_SUPPORT_VERSION    
-  //ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-  //                      (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-  //  ret_val = helper_args->return_value;
-  //					
-  //#else
-  //  ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  //#endif
 
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {
@@ -10504,13 +10481,7 @@ VALUE ibm_db_fetch_both(int argc, VALUE *argv, VALUE self)
   helper_args->error       =  &error;
   helper_args->funcType    =  FETCH_BOTH;
 
-  #ifdef UNICODE_SUPPORT_VERSION    
-	 ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_bind_fetch_helper, helper_args,
-                        (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res );
-	ret_val = helper_args->return_value;
-  #else
-    ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
-  #endif
+  ret_val = _ruby_ibm_db_bind_fetch_helper( helper_args );
 
   /*Free Memory Allocated*/
   if ( helper_args != NULL) {


### PR DESCRIPTION
Fixes Issue #11 

I was able to replicate it with standalone gem like this:
```
require 'ibm_db'
Thread.new { loop{ sleep(1); GC.start } }

conn = IBM_DB.connect "db", "user","password"
stmt = IBM_DB.exec conn,'select * from prefs limit 100000'
while (a = IBM_DB.fetch_assoc(stmt)) do
  puts a.inspect
end
```
Similar replication steps can be achieved through active record. `_ruby_ibm_db_bind_fetch_helper` is not safe to run with the GVL released. This prevents that from happening. 