### PR TITLE
AbstractAdapter fixes for Rails 5

### DIFF
--- a/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
+++ b/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
@@ -750,6 +750,7 @@ module ActiveRecord
 
       def initialize(connection, ar3, logger, config, conn_options)
         # Caching database connection configuration (+connect+ or +reconnect+ support)
+        @config           = config
         @connection       = connection
 		@isAr3            = ar3
         @conn_options     = conn_options
@@ -779,7 +780,7 @@ module ActiveRecord
 
         # Calls the parent class +ConnectionAdapters+' initializer
         # which sets @connection, @logger, @runtime and @last_verification
-        super(@connection, logger)
+        super(@connection, logger, config)
 
         if @connection
           server_info = IBM_DB.server_info( @connection )


### PR DESCRIPTION
Starting in rails 5.0, the initializer for AbstractAdapter changed

https://github.com/rails/rails/commit/8c53b2039e01b1a684a46c000f0ef29adcc1559c

This makes the ibm_db gem compatible with the latest octopus sharding gem version.  The line:

```super(@connection, logger, config)```

fixes the rails 5 AbstractAdapter change, and the line

```@config = config```

backpatches the issue for rails 3 and 4, so that the octopus gem and ibm_db will still work with older versions of rails.