### PR TITLE
Fix for empty_insert_statement_value method definition

### DIFF
--- a/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
+++ b/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
@@ -92,7 +92,7 @@ module ActiveRecord
 
 
 			if values.empty? # empty insert
-				im.values = Arel.sql(connection.empty_insert_statement_value(klass.primary_key))
+				im.values = Arel.sql(connection.empty_insert_statement_value)
 			else
 				im.insert substitutes
 			end


### PR DESCRIPTION
The ActiveRecord definition for `empty_insert_statement_value` has no arguments.  When mixing the ibm_db gem in with the mysql gem, this surfaces this error when creating a new object:
```
  ArgumentError:
    wrong number of arguments (given 1, expected 0)
    ./gemfiles/.bundle/ruby/2.5.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:257:in `empty_insert_statement_value'
    ./lib/octopus/proxy.rb:25:in `empty_insert_statement_value'
    ./gemfiles/.bundle/ruby/2.5.0/gems/ibm_db-4.0.0/lib/active_record/connection_adapters/ibm_db_adapter.rb:95:in `insert'
```