### PR TITLE
Binary mode conversion

### DIFF
--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -394,8 +394,8 @@ static void ruby_ibm_db_check_if_cli_func_supported() {
 
 static void ruby_ibm_db_init_globals(struct _ibm_db_globals *ibm_db_globals)
 {
-  /* env handle */
-  ibm_db_globals->bin_mode = 1;
+  /* Default binary conversion mode is to CONVERT binary => hex */
+  ibm_db_globals->bin_mode = CONVERT;
 
   memset(ibm_db_globals->__ruby_conn_err_msg, '\0', DB2_MAX_ERR_MSG_LEN);
   memset(ibm_db_globals->__ruby_stmt_err_msg, '\0', DB2_MAX_ERR_MSG_LEN);
@@ -1314,6 +1314,18 @@ static VALUE _ruby_ibm_db_assign_options( void *handle, int type, long opt_key, 
 #ifdef UNICODE_SUPPORT_VERSION
   VALUE data_utf16 = Qnil;
 #endif
+
+  /* When IBM_DB::BINARY is set to IBM_DB::CONVERT, bit data
+   * is converted to hex.  When IBM_DB::BINARY => IBM_DB::BINARY,
+   * binary data is returned.
+   */
+  if ( opt_key == BINARY )
+  {
+	if ( type == SQL_HANDLE_STMT)
+	  ((stmt_handle*)handle)->s_bin_mode = NUM2LONG(data);
+	else if ( type == SQL_HANDLE_DBC )
+	  ((conn_handle*)handle)->c_bin_mode = NUM2LONG(data);
+  }
 
   /* First check to see if it is a non-cli attribut */
   if (opt_key == ATTR_CASE) {

--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -6361,9 +6361,14 @@ static int _ruby_ibm_db_bind_parameter_helper(stmt_handle *stmt_res, param_node 
 #endif /* PASE */
         case SQL_VARBINARY:
         case SQL_XML:
-         /* account for bin_mode settings as well */
           curr->bind_indicator             =  curr->ivalue;
-          valueType                        =  SQL_C_BINARY;
+
+          /* account for bin_mode settings as well */
+          if ( stmt_res->s_bin_mode == CONVERT )
+            valueType                      =  SQL_C_CHAR;
+          else
+            valueType                      =  SQL_C_BINARY;
+
           bindParameter_args->buff_length  =  curr->ivalue;
           paramValuePtr                    =  (SQLPOINTER)curr->svalue;
           break;

--- a/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
+++ b/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
@@ -1645,6 +1645,8 @@ module ActiveRecord
                 # Quoting required for the default value of a column				
                 @servertype.set_binary_default(value)
               end
+          elsif column && column.sql_type.to_s =~ /for bit data/i
+            "x'#{value}'"
           elsif column && column.sql_type.to_s =~ /text|clob/i
               unless caller[0] =~ /add_column_options/i
                 @servertype.set_text_default(quote_string(value))


### PR DESCRIPTION
This converts all binary packed `FOR BIT DATA` fields into strings.
You can still turn this off by setting
```ruby:
IBM_DB.set_option(connnection, {IBM_DB::BINARY => IBM_DB::BINARY}, 1)
```

or when connecting:

```ruby:
connnection = IBM_DB.connect("server", "...", "...",
  {IBM_DB::BINARY => IBM_DB::BINARY})
```

This does the conversion for both parameter binding on prepared statements, and column conversions on result sets.
