### PR TITLE
Fixes intermittent segfault on startup connection

### DIFF
--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -2527,9 +2527,10 @@ static VALUE _ruby_ibm_db_connect_helper( int argc, VALUE *argv, int isPersisten
   }
   /* Call the function where the actual logic is being run*/
   #ifdef UNICODE_SUPPORT_VERSION
-	
+    /* Causes segfault on startup, call function directly instead 
 	ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_connect_helper2, helper_args, (void *)_ruby_ibm_db_Connection_level_UBF, NULL);	
-	
+	*/
+    _ruby_ibm_db_connect_helper2( helper_args );
 				
     conn_res = helper_args->conn_res;
 	


### PR DESCRIPTION
This segfault happens when starting up the rails app, and connecting to the database.  Similar to @codygustafson's fixes in #86, it seems that the threaded connections cause problems in the Ruby VM.

```
App 7754 stderr:
/opt/ruby23/lib/ruby/gems/2.3.0/gems/passenger-5.0.6/lib/phusion_passenger/request_handler.rb:395:
[BUG]
App 7754 stderr: vm_call0_cfunc_with_frame: cfp consistency error
App 7754 stderr: ruby 2.3.3p222 (2016-11-21 revision 56859)
[x86_64-linux-gnu]
```
```
App 8797 stderr: -- C level backtrace information
-------------------------------------------

/opt/ruby23/lib/libruby.so.2.3 [0x7f2822a1dad5]
/opt/ruby23/lib/libruby.so.2.3 [0x7f2822a1e623]
/opt/ruby23/lib/libruby.so.2.3(rb_bug+0xd6) [0x7f28228eeac6]

/opt/ruby23/lib/libruby.so.2.3 [0x7f2822a15c00]

/opt/ruby23/lib/libruby.so.2.3(rb_funcall+0x210) [0x7f2822a0a690]

bundle/ruby/2.3.0/bundler/gems/ruby-ibmdb-b147c95f2f82/IBM_DB_Adapter/ibm_db/lib/ibm_db.so(_ruby_ibm_db_parse_options+0x37)
[0x7f2812a47c77] ibm_db.c:1592

bundle/ruby/2.3.0/bundler/gems/ruby-ibmdb-b147c95f2f82/IBM_DB_Adapter/ibm_db/lib/ibm_db.so(_ruby_ibm_db_connect_helper2+0x186)
[0x7f2812a48076] ibm_db.c:2228

/opt/ruby23/lib/libruby.so.2.3 [0x7f2822a2c59b]

bundle/ruby/2.3.0/bundler/gems/ruby-ibmdb-b147c95f2f82/IBM_DB_Adapter/ibm_db/lib/ibm_db.so(ibm_Ruby_Thread_Call+0xb)
[0x7f2812a3ab0b] ibm_db.c:700

bundle/ruby/2.3.0/bundler/gems/ruby-ibmdb-b147c95f2f82/IBM_DB_Adapter/ibm_db/lib/ibm_db.so(_ruby_ibm_db_connect_helper+0x1f6)
[0x7f2812a46e26] ibm_db.c:2543
```