### PR TITLE
fixing an issue where the numeric field data type in db2 is ignored, …

### DIFF
--- a/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
+++ b/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
@@ -2196,7 +2196,7 @@ module ActiveRecord
                      column_length == '' || 
                      column_type.sub!(/ \(\) for bit data/i,"(#{column_length}) FOR BIT DATA") || 
                      !column_type =~ /char|lob|graphic/i
-                if column_type =~ /decimal/i
+                if column_type =~ /decimal|numeric/i
                   column_type << "(#{column_length},#{column_scale})"
                 elsif column_type =~ /smallint|integer|double|date|time|timestamp|xml|bigint/i
                   column_type << ""  # override native limits incompatible with table create


### PR DESCRIPTION
…therefore it loses the scale from any decimal values it tries to store.

If the DB2 column data type is numeric, then Activerecord sees the column as DecimalWithoutScale, and it loses the scale.

e.g. 33.34 will become and will be stored as 33
