### PR TITLE
Build fixes for GCC 10.2.1 on Debian 11.2

### DIFF
--- a/IBM_DB_Adapter/ibm_db/IBM_DB.gemspec
+++ b/IBM_DB_Adapter/ibm_db/IBM_DB.gemspec
@@ -17,7 +17,6 @@ SPEC = Gem::Specification.new do |spec|
   spec.author = 'IBM'
   spec.email = 'opendev@us.ibm.com'
   spec.homepage = 'https://github.com/ibmdb/ruby-ibmdb'
-  spec.rubyforge_project = 'rubyibm'
   spec.required_ruby_version = '>= 2.5.0'
   spec.add_dependency('activerecord', '>= 5.0.7', '<=6.0.3')
   spec.requirements << 'ActiveRecord, at least 5.0.7'
@@ -53,7 +52,6 @@ SPEC = Gem::Specification.new do |spec|
   end
 
   spec.test_file = 'test/ibm_db_test.rb'
-  spec.has_rdoc = true
   spec.extra_rdoc_files = ["CHANGES", "README", "MANIFEST"]
   spec.post_install_message = "\n*****************************************************************************\nSuccessfully installed ibm_db, the Ruby gem for IBM DB2/Informix.  The Ruby gem is licensed under the MIT License.   The package also includes IBM ODBC and CLI Driver from IBM, which could have been automatically downloaded as the Ruby gem is installed on your system/device.   The license agreement to the IBM driver is available in the folder \"$GEM_HOME/ibm_db-*/lib/clidriver/license\".  Check for additional dependencies, which may come with their own license agreement(s). Your use of the components of the package and dependencies constitutes your acceptance of their respective license agreements.  If you do not accept the terms of any license agreement(s), then delete the relevant component(s) from your system/device.\n*****************************************************************************\n\n FOR WINDOWS PLEASE SET RUBY_DLL_PATH=/path/to/clidriver/bin \n\n **************************************************** \n\n"
 end

--- a/IBM_DB_Adapter/ibm_db/ext/.gitignore
+++ b/IBM_DB_Adapter/ibm_db/ext/.gitignore
@@ -1,3 +1,5 @@
+*.o
+*.so
 *.log
 Makefile
 gil_release_version.h

--- a/IBM_DB_Adapter/ibm_db/ext/.gitignore
+++ b/IBM_DB_Adapter/ibm_db/ext/.gitignore
@@ -1,0 +1,4 @@
+*.log
+Makefile
+gil_release_version.h
+unicode_support_version.h

--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -100,10 +100,12 @@ typedef struct _ibm_db_fetch_helper_struct {
 void ruby_init_ibm_db();
 
 /* equivalent functions on different platforms */
-#ifdef _WIN32
-#define STRCASECMP stricmp
-#else
-#define STRCASECMP strcasecmp
+#ifndef STRCASECMP
+#  ifdef _WIN32
+#    define STRCASECMP stricmp
+#  else
+#    define STRCASECMP strcasecmp
+#  endif
 #endif
 
 static VALUE mDB;

--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -5665,7 +5665,7 @@ static int _ruby_ibm_db_do_prepare(conn_handle *conn_res, VALUE stmt, stmt_handl
       if ( rc == SQL_ERROR ) {
         ruby_xfree( prepare_args );
         prepare_args = NULL;
-        rb_warn( RSTRING_PTR(error) );
+        rb_warn( "%s", RSTRING_PTR(error) );
         return rc;
       }
     }
@@ -5805,7 +5805,7 @@ VALUE ibm_db_exec(int argc, VALUE *argv, VALUE self)
           stmt_res = NULL;
           ruby_xfree( exec_direct_args );
           exec_direct_args = NULL;
-          rb_warn( RSTRING_PTR(error) );
+          rb_warn( "%s", RSTRING_PTR(error) );
           return Qfalse;
         }
       }
@@ -7016,7 +7016,7 @@ VALUE ibm_db_execute(int argc, VALUE *argv, VALUE self)
     #endif
 
     if( ret_value == Qnil || ret_value == Qfalse ) {
-      rb_warn( RSTRING_PTR(error) );
+      rb_warn( "%s", RSTRING_PTR(error) );
       ruby_xfree( bind_array );
       bind_array = NULL;
       return Qfalse;
@@ -9273,7 +9273,7 @@ VALUE ibm_db_result(int argc, VALUE *argv, VALUE self)
   }
 
   if( error != Qnil && ret_val == Qnil) {
-    rb_warn( RSTRING_PTR(error) );
+    rb_warn( "%s", RSTRING_PTR(error) );
     ret_val = Qnil;
   }
 
@@ -10564,7 +10564,7 @@ VALUE ibm_db_set_option(int argc, VALUE *argv, VALUE self)
       if ( !NIL_P(r_options) ) {
         rc = _ruby_ibm_db_parse_options( r_options, SQL_HANDLE_DBC, conn_res, &error );
         if (rc == SQL_ERROR) {
-          rb_warn( RSTRING_PTR(error) );
+          rb_warn( "%s", RSTRING_PTR(error) );
           return Qfalse;
         }
       }
@@ -10574,7 +10574,7 @@ VALUE ibm_db_set_option(int argc, VALUE *argv, VALUE self)
       if ( !NIL_P(r_options) ) {
         rc = _ruby_ibm_db_parse_options( r_options, SQL_HANDLE_STMT, stmt_res, &error );
         if (rc == SQL_ERROR) {
-          rb_warn( RSTRING_PTR(error) );
+          rb_warn( "%s", RSTRING_PTR(error) );
           return Qfalse;
         }
       }

--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -28,10 +28,7 @@
 #include "ruby_ibm_db.h"
 #include <ctype.h>
 
-#ifdef RUBY_THREAD_H
-	#include <ruby/thread.h>
-#endif
-
+#include <ruby/thread.h>
 #include <ruby/version.h>
 
 /* True global resources - no need for thread safety here */
@@ -686,29 +683,12 @@ static void _ruby_ibm_db_mark_stmt_struct(stmt_handle *handle)
 {
 }
 
-
+static inline
 VALUE ibm_Ruby_Thread_Call(rb_blocking_function_t *func, void *data1, rb_unblock_function_t *ubf, void *data2)
 {
-	#ifdef RUBY_API_VERSION_MAJOR	
-		if( RUBY_API_VERSION_MAJOR >=2 && RUBY_API_VERSION_MINOR >=2) 
-		{	
-			#ifdef _WIN32
-				void *(*f)(void*) = (void *(*)(void*))func;
-				return (VALUE)rb_thread_call_without_gvl(f, data1, ubf, data2);
-			#elif __APPLE__
-				return rb_thread_call_without_gvl(func, data1, ubf, data2);                	   
-			#else
-				rb_thread_call_without_gvl(func, data1, ubf, data2);
-	                #endif	
-		}		
-		else	
-		{
-			rb_thread_call_without_gvl(func, data1, ubf, data2);
-		}
-	#else
-		rb_thread_call_without_gvl(func, data1, ubf, data2);
-	#endif
-  }
+	void *(*f)(void*) = (void *(*)(void*))func;
+	return (VALUE)rb_thread_call_without_gvl(f, data1, ubf, data2);
+}
   
 
 /*  */

--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -2337,7 +2337,7 @@ static VALUE _ruby_ibm_db_connect_helper2( connect_helper_args *data ) {
         handleAttr_args->handle      =  &( conn_res->hdbc );
         handleAttr_args->strLength   =  SQL_IS_INTEGER;
         handleAttr_args->attribute   =  SQL_ATTR_REPLACE_QUOTED_LITERALS;
-        handleAttr_args->valuePtr    =  (SQLPOINTER)(enable_numeric_literals);
+        handleAttr_args->valuePtr    =  (SQLPOINTER)(size_t)(enable_numeric_literals);
         rc = _ruby_ibm_db_SQLSetConnectAttr_helper( handleAttr_args );
         if (rc != SQL_SUCCESS) {
           handleAttr_args->attribute =  SQL_ATTR_REPLACE_QUOTED_LITERALS_OLDVALUE;
@@ -2514,7 +2514,7 @@ static VALUE _ruby_ibm_db_connect_helper( int argc, VALUE *argv, int isPersisten
 	
 	if(helper_args->isPersistent)
 	{
-		if(helper_args-> entry == NULL)
+		if(helper_args-> entry == (VALUE)0)
 		{
 			return_value = Qnil;
 		}
@@ -3302,7 +3302,7 @@ VALUE ibm_db_autocommit(int argc, VALUE *argv, VALUE self)
         handleAttr_args->attribute   =  SQL_ATTR_AUTOCOMMIT;
 
 #ifndef PASE
-        handleAttr_args->valuePtr = (SQLPOINTER)autocommit;
+        handleAttr_args->valuePtr = (SQLPOINTER)(size_t)autocommit;
 #else
         handleAttr_args->valuePtr = (SQLPOINTER)&autocommit;
 #endif


### PR DESCRIPTION
1. rb_warn() should not get external data as a format string - that is unsafe, and is detected as errors by recent versions of GCC.
2. STRCASECMP is currently defined in ruby.h, no need to re-define it - so added a check whether it has already been defined
3. added .gitignore to skip generated files in IBM_DB_Adapter/ibm_db/ext
