### PR TITLE
Fixed a suspicious typo in ibm_db_bind_param_helper()

### DIFF
--- a/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
+++ b/IBM_DB_Adapter/ibm_db/ext/ibm_db.c
@@ -3456,7 +3456,7 @@ VALUE ibm_db_bind_param_helper(int argc, char * varname, long varname_len ,long 
     case 3:
       param_type = SQL_PARAM_INPUT;
       
-      #ifdef UNICODE_SUPPORT_VERSIO
+      #ifdef UNICODE_SUPPORT_VERSION_H
                	ibm_Ruby_Thread_Call ( (void *)_ruby_ibm_db_SQLDescribeParam_helper, data,
                          (void *)_ruby_ibm_db_Statement_level_UBF, stmt_res);
 		rc = data->rc;


### PR DESCRIPTION
The code uses the "UNICODE_SUPPORT_VERSION_H", while in ibm_db_bind_param_helper() "UNICODE_SUPPORT_VERSIO" is used.

Signed-off-by: Maksim Zinal <mzinal@ru.ibm.com>