### PR TITLE
Fix the generated SQL for when LIMIT and/or OFFSET are being used

### DIFF
--- a/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
+++ b/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
@@ -3759,15 +3759,13 @@ module Arel
   class IBM_DB < Arel::Visitors::ToSql
     private
       def visit_Arel_Nodes_Limit(o, collector)
-        collector << " FETCH FIRST "
+        collector << " LIMIT "
         visit o.expr, collector
-        collector << " ROWS ONLY "
       end
 
       def visit_Arel_Nodes_Offset(o, collector)
         collector << " OFFSET "
         visit o.expr, collector
-        collector << " ROWS"
       end
 
       def visit_Arel_Nodes_ValuesList(o, collector)
@@ -3810,12 +3808,10 @@ module Arel
         end
 
         if (o.offset && o.limit)
-          visit_Arel_Nodes_Offset(o.offset, collector)
           visit_Arel_Nodes_Limit(o.limit, collector)
+          visit_Arel_Nodes_Offset(o.offset, collector)
         elsif (o.offset && o.limit.nil?)
-          collector << " OFFSET "
-          visit o.offset.expr, collector
-          collector << " ROWS "
+          visit_Arel_Nodes_Offset(o.offset, collector)
           maybe_visit o.lock, collector
         else
           visit_Arel_Nodes_SelectOptions(o, collector)


### PR DESCRIPTION
Hi @praveen-db2,

This fixes the following issue: https://github.com/ibmdb/ruby-ibmdb/issues/157
When combining `.offset()` and `.limit()` with ActiveRecord, invalid SQL is generated:

`Product.limit(10).offset(5)` produces this invalid query:

```SELECT products.* FROM products OFFSET 5 ROWS FETCH FIRST 10 ROWS ONLY```

That leads to this error:

```
ActiveRecord::StatementInvalid (ActiveRecord::StatementInvalid: [IBM][CLI Driver][DB2/SUNX8664] SQL0104N  An unexpected token "5 ROWS" was found following "or inspect */ OFFSET".  Expected tokens may include:  "<space>".  SQLSTATE=42601 SQLCODE=-104)
```

This is the syntax that should be generated:

```SELECT products.* FROM products LIMIT 10 OFFSET 5```

`LIMIT` has to come before `OFFSET`.

Please note that I was not able to run this code locally or run the unit tests. **This is completely untested!**

 It seems like running the unit tests requires me to set up a local dev environment for rails itself and then copy the test files over the Activerecord tests. I hope you can run the tests on your machine.