### PR TITLE
Specify Rails 7.2 in gemspec

### DIFF
--- a/IBM_DB_Adapter/ibm_db/IBM_DB.gemspec
+++ b/IBM_DB_Adapter/ibm_db/IBM_DB.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
   spec.add_dependency('rubyzip', '>= 2.3.2')
   spec.add_dependency('down')
-  spec.add_dependency 'rails', '>= 7.0', '< 7.3'
-  spec.add_dependency 'activerecord', '>= 7.0', '< 7.3'
+  spec.add_dependency 'rails', '>= 7.2', '< 7.3'
+  spec.add_dependency 'activerecord', '>= 7.2', '< 7.3'
 
   candidates = Dir.glob("**/*")
   spec.files = candidates.delete_if do |item|


### PR DESCRIPTION
It only supports 7.2 now, right? Then please consider this PR which adds that info also to the gemspec. 

Refs #184 / #182

If it's not intended – there's an error right away when using the latest ibm_db version within a Rails 7.1 app:

```
~/.gem/ruby/3.4.1/bundler/gems/ruby-ibmdb-2fab7f1be5cb/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb:22:in '<main>': undefined method 'register' for module ActiveRecord::ConnectionAdapters (NoMethodError)

ActiveRecord::ConnectionAdapters.register(
                                ^^^^^^^^^
```