### PR TITLE
Update ibm_db_adapter.rb

### DIFF
--- a/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
+++ b/IBM_DB_Adapter/ibm_db/lib/active_record/connection_adapters/ibm_db_adapter.rb
@@ -852,6 +852,8 @@ module ActiveRecord
                 @servertype = IBM_DB2_ZOS.new(self, @isAr3)
               when /12/
                 @servertype = IBM_DB2_ZOS.new(self, @isAr3)
+              when /13/
+                @servertype = IBM_DB2_ZOS.new(self, @isAr3)
               when /08/             # DB2 for zOS version 8
                 @servertype = IBM_DB2_ZOS_8.new(self, @isAr3)
               else # DB2 for zOS version 7


### PR DESCRIPTION
Let server DB2 version 13 work when initializing connection with IBM_DB2_ZOS instance. In my (limited) testing, this works fine. In fact, I've monkey-patched previous versions this way too. But, I don't know if there are any other DB2 server version 13 issues that need to be addressed.